### PR TITLE
refactor(exports): replace default export with named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ SOME_CONDITIONAL=false
 ```
 
 ```ts
-import booleanize from '@wkovacs64/booleanize';
+import { booleanize } from '@wkovacs64/booleanize';
 
 Boolean(process.env.SOME_CONDITIONAL); // true 😕
 booleanize(process.env.SOME_CONDITIONAL); // false 😊

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-const booleanize = (
+export const booleanize = (
   input: boolean | number | bigint | string | null | undefined,
 ): boolean => {
   if (input === null) return false;
@@ -25,5 +25,3 @@ const booleanize = (
 
   throw new Error(`Unable to booleanize type: ${typeof input}`);
 };
-
-export default booleanize;

--- a/test/booleanize.test.ts
+++ b/test/booleanize.test.ts
@@ -1,4 +1,4 @@
-import booleanize from '../src/index';
+import { booleanize } from '../src/index';
 
 describe('booleanize', () => {
   it('returns false for falsy values', () => {


### PR DESCRIPTION
Default exports are still problematic. Named exports are just easier and work better.

BREAKING CHANGE: The default export has been removed and replaced with a named export. Your
import/require statements should be updated accordingly.