### PR TITLE
chore(deps): reduce minimum release age from 7 days to 3

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 4320
+
 allowBuilds:
   esbuild: false
   unrs-resolver: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
-minimumReleaseAge: 4320
-
 allowBuilds:
   esbuild: false
   unrs-resolver: false
+
+minimumReleaseAge: 4320

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "packageRules": [
     {
       "matchDatasources": ["npm"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchPackageNames": ["eslint"],


### PR DESCRIPTION
## Summary
- reduce Renovate minimum release age from 7 days to 3 days
- set pnpm minimumReleaseAge to 4320 minutes

## Validation
- pnpm format
