### PR TITLE
chore: reduce pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@ allowBuilds:
   esbuild: false
   unrs-resolver: false
 
-minimumReleaseAge: 4320
+minimumReleaseAge: 1440


### PR DESCRIPTION
Sets `minimumReleaseAge` to 1440 minutes (24 hours).