### PR TITLE
chore: remove redundant Oxlint path

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "changeset:publish": "changeset publish",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "lint": "oxlint .",
+    "lint": "oxlint",
     "prepare": "pnpm run --silent build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

- remove the redundant `.` argument from the Oxlint script

## Validation

- `pnpm format`
- `pnpm lint`